### PR TITLE
use default renderer to prevent GPUParticles crash on macos

### DIFF
--- a/project.godot
+++ b/project.godot
@@ -60,3 +60,4 @@ textures/vram_compression/import_etc2_astc=true
 environment/defaults/default_clear_color=Color(0.301961, 0.301961, 0.301961, 1)
 2d/snap/snap_2d_transforms_to_pixel=true
 2d/snap/snap_2d_vertices_to_pixel=true
+renderer/rendering_method.macos="forward_plus"


### PR DESCRIPTION
Hi,

First of all, nice project! I tried to run it, but the project silently crashes after pressing 'Explore'. After quickly debugging I believe it's related with GPUParticles not working properly on macos M series ( https://github.com/godotengine/godot/issues/72469 ). This pr works around the problem by setting the default renderer in project.godot