### PR TITLE
ADF-8 | Linter/formatter venv support

### DIFF
--- a/addons/gdLinter/gdLinter.gd
+++ b/addons/gdLinter/gdLinter.gd
@@ -4,17 +4,18 @@ extends EditorPlugin
 
 const DockScene := preload("res://addons/gdLinter/UI/Dock.tscn")
 
-
 var icon_error := EditorInterface.get_editor_theme().get_icon("Error", "EditorIcons")
-var color_error: Color = EditorInterface.get_editor_settings()\
-		.get_setting("text_editor/theme/highlighting/comment_markers/critical_color")
+var color_error: Color = EditorInterface.get_editor_settings().get_setting(
+	"text_editor/theme/highlighting/comment_markers/critical_color"
+)
 
 var icon_error_ignore := EditorInterface.get_editor_theme().get_icon("ErrorWarning", "EditorIcons")
 var icon_ignore := EditorInterface.get_editor_theme().get_icon("Warning", "EditorIcons")
 
 var icon_success := EditorInterface.get_editor_theme().get_icon("StatusSuccess", "EditorIcons")
-var color_success: Color = EditorInterface.get_editor_settings()\
-	.get_setting("text_editor/theme/highlighting/comment_markers/notice_color")
+var color_success: Color = EditorInterface.get_editor_settings().get_setting(
+	"text_editor/theme/highlighting/comment_markers/notice_color"
+)
 
 var bottom_panel_button: Button
 var highlight_lines: PackedInt32Array
@@ -32,25 +33,26 @@ func _enter_tree() -> void:
 	_dock_ui = DockScene.instantiate()
 	_dock_ui.gd_linter = self
 	bottom_panel_button = add_control_to_bottom_panel(_dock_ui, "GDLint")
-	
+
 	# connect signal to lint on save
 	resource_saved.connect(on_resource_saved)
-	
+
 	script_editor = EditorInterface.get_script_editor()
 	script_editor.editor_script_changed.connect(_on_editor_script_changed)
 	_gdlint_path = get_gdlint_path()
 	get_gdlint_version()
 	prints("Loading GDLint Plugin success")
 
+
 # TODO: Reenable again?
 # Dunno how highlighting lines in Godot works, since it get removed after a second or so
 # So I use this evil workaround straight from hell:
 #func _process(_delta: float) -> void:
-	#if not get_current_editor():
-		#return
-	#
-	#if not highlight_lines.is_empty():
-		#set_line_color(color_error)
+#if not get_current_editor():
+#return
+#
+#if not highlight_lines.is_empty():
+#set_line_color(color_error)
 
 
 func _on_editor_script_changed(script: Script) -> void:
@@ -72,7 +74,7 @@ func _exit_tree() -> void:
 	if is_instance_valid(_dock_ui):
 		remove_control_from_bottom_panel(_dock_ui)
 		_dock_ui.free()
-	
+
 	if Engine.get_version_info().hex >= 0x40201:
 		prints("Unload GDLint Plugin success")
 
@@ -80,13 +82,13 @@ func _exit_tree() -> void:
 func on_resource_saved(resource: Resource) -> void:
 	if not resource is GDScript:
 		return
-	
+
 	_dock_ui.clear_items()
 	clear_highlights()
-	
+
 	# Show resource path in the GDLint Dock
 	_dock_ui.file.text = resource.resource_path
-	
+
 	# Execute linting and get its output
 	var filepath: String = ProjectSettings.globalize_path(resource.resource_path)
 	var gdlint_output: Array = []
@@ -94,41 +96,41 @@ func on_resource_saved(resource: Resource) -> void:
 	var exit_code = OS.execute(_gdlint_path, [filepath], gdlint_output, true)
 	if not exit_code == -1:
 		var output_string: String = gdlint_output[0]
-		output_array = output_string.replace(filepath+":", "Line ").split("\n")
-	
+		output_array = output_string.replace(filepath + ":", "Line ").split("\n")
+
 		_dock_ui.set_problems_label(_dock_ui.num_problems)
 		_dock_ui.set_ignored_problems_label(_dock_ui.num_ignored_problems)
-	
+
 	# Workaround until unique name bug is fixed
 	# https://github.com/Scony/godot-gdscript-toolkit/issues/284
 	# Hope I won't break other stuff with it
 	if not output_array.size() or output_array[0] == "Line ":
 		printerr("gdLint Error: ", output_array, "\n File can't be linted!")
 		return
-	
+
 	# When there is no error
 	if output_array.size() <= 2:
 		bottom_panel_button.add_theme_constant_override(&"icon_max_width", 8)
 		bottom_panel_button.icon = icon_success
 		return
-	
+
 	# When errors are found create buttons in the dock
-	for i in output_array.size()-2:
+	for i in output_array.size() - 2:
 		var regex := RegEx.new()
 		regex.compile("\\d+")
 		var result := regex.search(output_array[i])
 		if result:
-			var current_line := int(result.strings[0])-1
+			var current_line := int(result.strings[0]) - 1
 			var error := output_array[i].rsplit(":", true, 1)
 			if len(error) > 1:
-				_dock_ui.create_item(current_line+1, error[1])
+				_dock_ui.create_item(current_line + 1, error[1])
 				if _dock_ui.is_error_ignored(error[1]):
 					continue
 				highlight_lines.append(current_line)
-	
+
 	_dock_ui.set_problems_label(_dock_ui.num_problems)
 	_dock_ui.set_ignored_problems_label(_dock_ui.num_ignored_problems)
-	
+
 	# Error, no Ignore
 	if _dock_ui.num_problems > 0 and _dock_ui.num_ignored_problems <= 0:
 		bottom_panel_button.icon = icon_error
@@ -147,13 +149,12 @@ func set_line_color(color: Color) -> void:
 	var current_code_editor := get_current_editor()
 	if current_code_editor == null:
 		return
-	
+
 	for line: int in highlight_lines:
 		# Skip line if this one is from the old code editor
-		if line > current_code_editor.get_line_count()-1:
+		if line > current_code_editor.get_line_count() - 1:
 			continue
-		current_code_editor.set_line_background_color(line,
-			color.darkened(0.5))
+		current_code_editor.set_line_background_color(line, color.darkened(0.5))
 
 
 func clear_highlights() -> void:
@@ -170,19 +171,25 @@ func get_current_editor() -> CodeEdit:
 
 func get_gdlint_path() -> String:
 	if OS.get_name() == "Windows":
+		# Get the executable in the venv directory in the project root
+		var venv_gdlint_executable := ProjectSettings.globalize_path(
+			"res://venv/Scripts/gdlint.exe"
+		)
+		if FileAccess.file_exists(venv_gdlint_executable):
+			return venv_gdlint_executable
 		return "gdlint"
-	
+
 	# macOS & Linux
 	var output := []
 	OS.execute("python3", ["-m", "site", "--user-base"], output)
 	var python_bin_folder := (output[0] as String).strip_edges().path_join("bin")
 	if FileAccess.file_exists(python_bin_folder.path_join("gdlint")):
 		return python_bin_folder.path_join("gdlint")
-	
+
 	# Linux dirty hardcoded fallback
 	if OS.get_name() == "Linux":
 		if FileAccess.file_exists("/usr/bin/gdlint"):
 			return "/usr/bin/gdlint"
-	
+
 	# Global fallback
 	return "gdlint"

--- a/readme.md
+++ b/readme.md
@@ -21,3 +21,30 @@ Current Version - [ PRE-ALPHA : WEEK 10 ]
 ![image](https://github.com/TinyTakinTeller/GodotProjectZero/assets/155020210/9b62ac2a-db9b-470e-9178-d85e1c033ca4)
 
 *And More...*
+
+
+## Development setup
+
+### Setup the GDScript Toolkit
+This project uses the [Format on Save](https://github.com/ryan-haskell/gdformat-on-save) and [gdLinter](https://github.com/el-falso/gdlinter) plugins.
+Both of these depend on the [GDScript Toolkit](https://github.com/Scony/godot-gdscript-toolkit) python package being installed.
+You can install this dependency globally or in a virtual environment.
+
+#### To install globally
+This is the standard way described in the documentation of the package
+```
+pip3 install "gdtoolkit==4.*"
+```
+
+#### To install in a virtual environment
+If you're on Windows, this project has some custom code in the "Format on Save" and "gdLinter" plugins to make it work with a `venv/` directory in the root of the project.
+```
+cd <path/to/this/project>
+python -m venv venv
+.\venv\Scripts\activate
+
+pip3 install "gdtoolkit==4.*"
+```
+Remarks 
+1. The `venv/` directory is in the `.gitignore`, so won't be committed to git
+2. Because of the custom code, the `venv` integration will break when we update the plugins


### PR DESCRIPTION
This is a preparation PR to see if this is what we want here (as it updates some of the code in the addons directory)

Why:
- I saw that there was a `/venv` directory in the `.gitignore`, so I assumed that's where to install the gdscript toolkit (https://github.com/Scony/godot-gdscript-toolkit)
- That didn't work, because the code of the addons expects a global executable to be available. I prefer to not rely on global packages, so in this PR I'm trying to make it work with `/venv`

In this PR:
- Linter and formatter addons use executables from the `/venv` directory (if available), and gdformat was applied to the touched files (I've marked the actual logic changes)
- It's only added for Windows for now
- Added some setup info to the readme.md

Note: There's the drawback that if we update the plugins, we should also transfer this venv-related code to the new versions