### PR TITLE
ADF 40 | Linter fixes for global directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,6 @@ venv/
 
 # VSCode
 .vscode/
+
+# Jetbrains (Rider)
+.idea/

--- a/addons/gdLinter/UI/Dock.gd
+++ b/addons/gdLinter/UI/Dock.gd
@@ -5,8 +5,9 @@ extends Control
 var gd_linter: GDLinter
 var error_descriptions := preload("res://addons/gdLinter/error_descriptions.gd").new()
 var script_text_editor: ScriptEditorBase
-var color_error: Color = EditorInterface.get_editor_settings()\
-		.get_setting("text_editor/theme/highlighting/comment_markers/critical_color")
+var color_error: Color = EditorInterface.get_editor_settings().get_setting(
+	"text_editor/theme/highlighting/comment_markers/critical_color"
+)
 
 var num_problems: int = 0
 var num_ignored_problems: int = 0
@@ -38,6 +39,7 @@ func _ready() -> void:
 	tree.set_column_expand_ratio(0, 4)
 	tree.item_activated.connect(_on_item_activated)
 
+
 func reset_problem_num() -> void:
 	num_problems = 0
 	num_ignored_problems = 0
@@ -51,12 +53,12 @@ func create_item(line: int, name: String) -> void:
 	if _ignore.get(str_dash_to_underscore(error_type)):
 		num_ignored_problems += 1
 		return
-	
+
 	var item := tree.create_item()
 	item.set_text(0, str(line))
 	item.set_text(1, name)
 	item.set_metadata(0, line)
-	
+
 	if error_descriptions.error.has(error_type):
 		item.set_tooltip_text(1, error_descriptions.error[error_type])
 	num_problems += 1
@@ -69,6 +71,7 @@ func set_problems_label(number: int) -> void:
 func set_ignored_problems_label(number: int) -> void:
 	ignored_problems_num.text = str(number)
 
+
 func clear_items() -> void:
 	reset_problem_num()
 	tree.clear()
@@ -78,7 +81,7 @@ func clear_items() -> void:
 func _on_item_activated() -> void:
 	var selected: TreeItem = tree.get_selected()
 	var line := selected.get_metadata(0)
-	
+
 	EditorInterface.edit_script(load(file.text), line)
 
 	if not EditorInterface.get_editor_settings().get("text_editor/external/use_external_editor"):

--- a/addons/gdLinter/UI/Name.gd
+++ b/addons/gdLinter/UI/Name.gd
@@ -28,7 +28,9 @@ func init() -> void:
 	class_variable_name.button_pressed = _owner.ignore.get("_class_variable_name")
 	class_load_variable_name.button_pressed = _owner.ignore.get("_class_load_variable_name")
 	function_variable_name.button_pressed = _owner.ignore.get("_function_variable_name")
-	function_preload_variable_name.button_pressed = _owner.ignore.get("_function_preload_variable_name")
+	function_preload_variable_name.button_pressed = _owner.ignore.get(
+		"_function_preload_variable_name"
+	)
 	function_argument_name.button_pressed = _owner.ignore.get("_function_argument_name")
 	loop_variable_name.button_pressed = _owner.ignore.get("_loop_variable_name")
 	enum_name.button_pressed = _owner.ignore.get("_enum_name")

--- a/addons/gdLinter/error_descriptions.gd
+++ b/addons/gdLinter/error_descriptions.gd
@@ -1,5 +1,6 @@
 extends Resource
 
+# gdlint:disable = max-line-length
 var error := {
 	#region Name Checks
 	"function-name": "Validates if function name conforms to snake_case, _private_snake_case, or _on_PascalCase_snake_case.",

--- a/global/autoload/audio/sfx_map/sfx_map.gd
+++ b/global/autoload/audio/sfx_map/sfx_map.gd
@@ -24,6 +24,9 @@ const SFX_ID: Dictionary = {
 	"cat_talking": KEYBOARD_TYPING
 }
 
+# we're expecting long file paths here, so don't check for line length
+# gdlint:disable = max-line-length
+
 const KEYBOARD_TYPING = preload(
 	"res://assets/audio/freesound_org/keyboard_typing/keyboard_typing.mp3"
 )

--- a/global/autoload/locale/locale.gd
+++ b/global/autoload/locale/locale.gd
@@ -1,6 +1,6 @@
 extends Node
 
-const LOCALE: Dictionary = {"en": LocaleEn.en}
+const LOCALE: Dictionary = {"en": LocaleEn.EN}
 const LOCALE_NAME: Dictionary = {"en": "English"}
 
 

--- a/global/autoload/locale/locale.gd
+++ b/global/autoload/locale/locale.gd
@@ -1,100 +1,100 @@
 extends Node
 
-const locale: Dictionary = {"en": LocaleEn.en}
-const locale_name: Dictionary = {"en": "English"}
+const LOCALE: Dictionary = {"en": LocaleEn.en}
+const LOCALE_NAME: Dictionary = {"en": "English"}
 
 
 func get_ui_label(id: String) -> String:
-	return locale[SaveFile.LOCALE]["ui_label"].get(id, "")
+	return LOCALE[SaveFile.locale]["ui_label"].get(id, "")
 
 
 func get_npc_hover_info(npc_id: String) -> String:
-	return locale[SaveFile.LOCALE]["npc_hover_info"].get(npc_id, "")
+	return LOCALE[SaveFile.locale]["npc_hover_info"].get(npc_id, "")
 
 
 func get_npc_hover_title(npc_id: String) -> String:
-	return locale[SaveFile.LOCALE]["npc_hover_title"].get(
+	return LOCALE[SaveFile.locale]["npc_hover_title"].get(
 		npc_id, StringUtils.humanify_string(npc_id)
 	)
 
 
 func get_npc_click_info(npc_id: String) -> String:
-	return locale[SaveFile.LOCALE]["npc_click_info"].get(npc_id, "")
+	return LOCALE[SaveFile.locale]["npc_click_info"].get(npc_id, "")
 
 
 func get_npc_click_title(npc_id: String) -> String:
-	return locale[SaveFile.LOCALE]["npc_click_title"].get(
+	return LOCALE[SaveFile.locale]["npc_click_title"].get(
 		npc_id, StringUtils.humanify_string(npc_id)
 	)
 
 
-func get_scale_settings_info(scale_: int) -> String:
-	return locale[SaveFile.LOCALE]["scale_settings_info"].get(
-		scale_, locale[SaveFile.LOCALE]["scale_settings_info"][-1]
+func get_scale_settings_info(scale: int) -> String:
+	return LOCALE[SaveFile.locale]["scale_settings_info"].get(
+		scale, LOCALE[SaveFile.locale]["scale_settings_info"][-1]
 	)
 
 
 func get_enemy_data_info(enemy_id: String) -> String:
-	return locale[SaveFile.LOCALE]["enemy_data_info"].get(enemy_id, "")
+	return LOCALE[SaveFile.locale]["enemy_data_info"].get(enemy_id, "")
 
 
 func get_enemy_data_option_title(enemy_id: String, option: int) -> String:
-	return locale[SaveFile.LOCALE]["enemy_data_option_title"].get(enemy_id + "-" + str(option), "?")
+	return LOCALE[SaveFile.locale]["enemy_data_option_title"].get(enemy_id + "-" + str(option), "?")
 
 
 func get_enemy_data_title(enemy_id: String) -> String:
-	return locale[SaveFile.LOCALE]["enemy_data_title"].get(
+	return LOCALE[SaveFile.locale]["enemy_data_title"].get(
 		enemy_id, StringUtils.humanify_string(enemy_id)
 	)
 
 
 func get_resource_generator_label(resource_id: String) -> String:
-	return locale[SaveFile.LOCALE]["resource_generator_label"].get(
+	return LOCALE[SaveFile.locale]["resource_generator_label"].get(
 		resource_id, StringUtils.humanify_string(resource_id)
 	)
 
 
 func get_resource_generator_title(resource_id: String) -> String:
-	return locale[SaveFile.LOCALE]["resource_generator_title"].get(
+	return LOCALE[SaveFile.locale]["resource_generator_title"].get(
 		resource_id, StringUtils.humanify_string(resource_id)
 	)
 
 
 func get_resource_generator_flavor(resource_id: String) -> String:
-	return locale[SaveFile.LOCALE]["resource_generator_flavor"].get(resource_id, "")
+	return LOCALE[SaveFile.locale]["resource_generator_flavor"].get(resource_id, "")
 
 
 func get_resource_generator_max_flavor(resource_id: String) -> String:
-	return locale[SaveFile.LOCALE]["resource_generator_max_flavor"].get(resource_id, "")
+	return LOCALE[SaveFile.locale]["resource_generator_max_flavor"].get(resource_id, "")
 
 
 func get_resource_generator_display_name(resource_id: String) -> String:
-	return locale[SaveFile.LOCALE]["resource_generator_display_name"].get(
+	return LOCALE[SaveFile.locale]["resource_generator_display_name"].get(
 		resource_id, StringUtils.humanify_string(resource_id)
 	)
 
 
 func get_worker_role_title(role_id: String) -> String:
-	return locale[SaveFile.LOCALE]["worker_role_title"].get(
+	return LOCALE[SaveFile.locale]["worker_role_title"].get(
 		role_id, StringUtils.humanify_string(role_id)
 	)
 
 
 func get_worker_role_flavor(role_id: String) -> String:
-	return locale[SaveFile.LOCALE]["worker_role_flavor"].get(role_id, "")
+	return LOCALE[SaveFile.locale]["worker_role_flavor"].get(role_id, "")
 
 
 func get_tab_data_titles(tab_id: String) -> Array:
-	return locale[SaveFile.LOCALE]["tab_data_titles"].get(tab_id, [])
+	return LOCALE[SaveFile.locale]["tab_data_titles"].get(tab_id, [])
 
 
 func get_event_data_text(event_id: String) -> String:
-	return locale[SaveFile.LOCALE]["event_data_text"].get(event_id, "")
+	return LOCALE[SaveFile.locale]["event_data_text"].get(event_id, "")
 
 
 func get_npc_event_text(event_id: String) -> String:
-	return locale[SaveFile.LOCALE]["npc_event_text"].get(event_id, "")
+	return LOCALE[SaveFile.locale]["npc_event_text"].get(event_id, "")
 
 
 func get_npc_event_options(event_id: String) -> Array:
-	return locale[SaveFile.LOCALE]["npc_event_options"].get(event_id, [])
+	return LOCALE[SaveFile.locale]["npc_event_options"].get(event_id, [])

--- a/global/autoload/save_file/save_file.gd
+++ b/global/autoload/save_file/save_file.gd
@@ -244,7 +244,7 @@ func _export_save_data() -> Dictionary:
 	save_data["npc_events"] = npc_events
 	save_data["enemy"] = enemy
 	save_data["metadata"] = metadata
-	save_data["locale"] = locale
+	save_data["LOCALE"] = locale
 	return save_data
 
 
@@ -318,7 +318,7 @@ func _get_metadata(save_data: Dictionary) -> Dictionary:
 
 
 func _get_locale(save_data: Dictionary) -> String:
-	return save_data.get("locale", locale)
+	return save_data.get("LOCALE", locale)
 
 
 func _update_metadata() -> void:

--- a/global/autoload/save_file/save_file.gd
+++ b/global/autoload/save_file/save_file.gd
@@ -4,8 +4,8 @@ const SIGNATURE = "$$$"
 const SAVE_FILE_EXTENSION = ".json"
 const AUTOSAVE_SECONDS: int = Game.params["autosave_seconds"]
 
-var ACTIVE_FILE_NAME: String = "default"
-var SAVE_DATAS: Dictionary = {}
+var active_file_name: String = "default"
+var save_datas: Dictionary = {}
 
 var resources: Dictionary = {}
 var workers: Dictionary = {}
@@ -24,7 +24,7 @@ var audio_settings: Dictionary = {
 var npc_events: Dictionary = {}
 var enemy: Dictionary = {"level": "rabbit", "rabbit": {"damage": 0}}
 var metadata: Dictionary = {}
-var LOCALE: String = "en"
+var locale: String = "en"
 
 @onready var autosave_timer: Timer = %AutosaveTimer
 
@@ -77,12 +77,12 @@ func get_enemy_damage(enemy_id: String = "") -> int:
 
 func get_settings_theme(save_file_name: String) -> Resource:
 	var theme_id: String = Game.params["default_theme"]
-	if !SAVE_DATAS.has(save_file_name):
+	if !save_datas.has(save_file_name):
 		return Resources.theme.get(theme_id, null)
 
-	var save_data: Dictionary = SAVE_DATAS[save_file_name]
-	var _settings: Dictionary = save_data.get("settings", {})
-	theme_id = _settings.get("theme", "")
+	var save_data: Dictionary = save_datas[save_file_name]
+	var saved_settings: Dictionary = save_data.get("settings", {})
+	theme_id = saved_settings.get("theme", "")
 	return Resources.theme.get(theme_id, null)
 
 
@@ -128,12 +128,12 @@ func add_enemy_damage(damage: int) -> int:
 
 
 func set_metadata_name(save_file_name: String, value: String) -> void:
-	if !SAVE_DATAS.has(save_file_name):
+	if !save_datas.has(save_file_name):
 		return
 
-	var save_data: Dictionary = SAVE_DATAS[save_file_name]
-	var _metadata: Dictionary = save_data.get("metadata", {})
-	_metadata["save_file_name"] = value
+	var save_data: Dictionary = save_datas[save_file_name]
+	var saved_metadata: Dictionary = save_data.get("metadata", {})
+	saved_metadata["save_file_name"] = value
 
 
 ###########
@@ -146,10 +146,10 @@ func initialize(save_file_name: String, metadata_name: String) -> void:
 		return
 
 	var file_name: String = save_file_name + SAVE_FILE_EXTENSION
-	ACTIVE_FILE_NAME = file_name
+	active_file_name = file_name
 
-	if SAVE_DATAS.has(save_file_name):
-		var save_data: Dictionary = SAVE_DATAS[save_file_name]
+	if save_datas.has(save_file_name):
+		var save_data: Dictionary = save_datas[save_file_name]
 		if save_data != null and !save_data.is_empty():
 			_import_save_data(save_data)
 	elif StringUtils.is_not_empty(metadata_name):
@@ -163,16 +163,16 @@ func delete(save_file_name: String) -> void:
 	var error: Error = DirAccess.remove_absolute(FileSystemUtils.USER_PATH + file_name)
 	if Game.params["debug_logs"]:
 		print("Delete save file '" + save_file_name + "' response: " + str(error))
-	SAVE_DATAS.erase(save_file_name)
+	save_datas.erase(save_file_name)
 
 
 func rename(save_file_name: String, new_text: String, old_text: String) -> void:
 	set_metadata_name(save_file_name, new_text)
 
 	var file_name: String = save_file_name + SAVE_FILE_EXTENSION
-	var to_replace: String = __metadata_save_file_name_internal(old_text)
-	var to_set: String = __metadata_save_file_name_internal(new_text)
-	__replace(file_name, to_replace, to_set)
+	var to_replace: String = _metadata_save_file_name_internal(old_text)
+	var to_set: String = _metadata_save_file_name_internal(new_text)
+	_replace(file_name, to_replace, to_set)
 
 
 #############
@@ -196,9 +196,9 @@ func _autosave(force: bool = false, silent: bool = false) -> void:
 	if not silent:
 		SignalBus.autosave.emit(seconds_delta, AUTOSAVE_SECONDS)
 
-	var file_name: String = ACTIVE_FILE_NAME
+	var file_name: String = active_file_name
 	_update_metadata()
-	__write(file_name)
+	_write(file_name)
 
 
 func _get_seconds_since_last_autosave() -> int:
@@ -218,7 +218,7 @@ func _load_save_files() -> void:
 	for file_name: String in FileSystemUtils.get_user_files():
 		if !file_name.ends_with(SAVE_FILE_EXTENSION):
 			continue
-		var save_data: Dictionary = __read(file_name)
+		var save_data: Dictionary = _read(file_name)
 		_check_backward_compatibility(save_data)
 		if Game.params["debug_logs"]:
 			print("__LOAD_SAVE_DATA: " + file_name)
@@ -226,7 +226,7 @@ func _load_save_files() -> void:
 		if save_data == null or save_data.is_empty():
 			continue
 		var save_file_name: String = file_name.trim_suffix(SAVE_FILE_EXTENSION)
-		SAVE_DATAS[save_file_name] = save_data
+		save_datas[save_file_name] = save_data
 
 
 func _export_save_data() -> Dictionary:
@@ -244,7 +244,7 @@ func _export_save_data() -> Dictionary:
 	save_data["npc_events"] = npc_events
 	save_data["enemy"] = enemy
 	save_data["metadata"] = metadata
-	save_data["LOCALE"] = LOCALE
+	save_data["locale"] = locale
 	return save_data
 
 
@@ -262,7 +262,7 @@ func _import_save_data(save_data: Dictionary) -> void:
 	npc_events = _get_npc_events(save_data)
 	enemy = _get_enemy(save_data)
 	metadata = _get_metadata(save_data)
-	LOCALE = _get_locale(save_data)
+	locale = _get_locale(save_data)
 
 
 func _get_resources(save_data: Dictionary) -> Dictionary:
@@ -318,7 +318,7 @@ func _get_metadata(save_data: Dictionary) -> Dictionary:
 
 
 func _get_locale(save_data: Dictionary) -> String:
-	return save_data.get("LOCALE", LOCALE)
+	return save_data.get("locale", locale)
 
 
 func _update_metadata() -> void:
@@ -460,7 +460,7 @@ func _on_offline_progress_processed(
 ##############
 
 
-func __write(file_name: String) -> void:
+func _write(file_name: String) -> void:
 	var save_data: Dictionary = _export_save_data()
 
 	_check_backward_corrupt_worker_role(save_data)
@@ -474,7 +474,7 @@ func __write(file_name: String) -> void:
 	save_file.close()
 
 
-func __read(file_name: String) -> Dictionary:
+func _read(file_name: String) -> Dictionary:
 	var path: String = FileSystemUtils.USER_PATH + file_name
 	if Game.params["debug_logs"]:
 		print()
@@ -488,12 +488,12 @@ func __read(file_name: String) -> Dictionary:
 	var content: String = save_file.get_as_text()
 	save_file.close()
 
-	content = __handle_corrupt_end_of_file(content)
+	content = _handle_corrupt_end_of_file(content)
 	content = content.replace(SIGNATURE, "")
 	if Game.params["debug_logs"]:
 		print("__READ_CONTENT: " + content)
 
-	var json_object: JSON = __parse(content)
+	var json_object: JSON = _parse(content)
 	if json_object == null:
 		if Game.params["debug_logs"]:
 			print("__READ_PARSE_FAILED")
@@ -506,22 +506,22 @@ func __read(file_name: String) -> Dictionary:
 	return save_data
 
 
-func __parse(content: String, retry: bool = true) -> JSON:
+func _parse(content: String, retry: bool = true) -> JSON:
 	var json_object: JSON = JSON.new()
-	var _parse_err: Error = json_object.parse(content)
-	if _parse_err != Error.OK:
+	var parse_err: Error = json_object.parse(content)
+	if parse_err != Error.OK:
 		if Game.params["debug_logs"]:
-			print("__READ_PARSE_ERROR: " + str(_parse_err))
+			print("__READ_PARSE_ERROR: " + str(parse_err))
 		if retry:
 			var retry_content: String = StringUtils.sanitize_text(content, StringUtils.ASCII)
 			if Game.params["debug_logs"]:
 				print("__READ_RETRY_PARSE_WITH_FORCE_ASCII_CONTENT: " + retry_content)
-			return __parse(retry_content, false)
+			return _parse(retry_content, false)
 		return null
 	return json_object
 
 
-func __replace(file_name: String, old_text: String, new_text: String) -> void:
+func _replace(file_name: String, old_text: String, new_text: String) -> void:
 	var path: String = FileSystemUtils.USER_PATH + file_name
 	var save_file: FileAccess = FileAccess.open(path, FileAccess.READ)
 	if save_file == null:
@@ -529,7 +529,7 @@ func __replace(file_name: String, old_text: String, new_text: String) -> void:
 	var content: String = save_file.get_as_text()
 	save_file.close()
 
-	content = __handle_corrupt_end_of_file(content)
+	content = _handle_corrupt_end_of_file(content)
 	content = content.replace(old_text, new_text)
 
 	save_file = FileAccess.open(path, FileAccess.WRITE)
@@ -538,7 +538,7 @@ func __replace(file_name: String, old_text: String, new_text: String) -> void:
 
 
 ## removes corrupt excess data from end of save file (underlying OS can fail a FileAccess operation)
-func __handle_corrupt_end_of_file(content: String) -> String:
+func _handle_corrupt_end_of_file(content: String) -> String:
 	var signature_index: int = content.find(SIGNATURE)
 	if signature_index == -1:
 		return content
@@ -546,5 +546,5 @@ func __handle_corrupt_end_of_file(content: String) -> String:
 	return new_content
 
 
-func __metadata_save_file_name_internal(value: String) -> String:
+func _metadata_save_file_name_internal(value: String) -> String:
 	return '"' + "save_file_name" + '"' + ":" + '"' + str(value) + '"'

--- a/global/const/game.gd
+++ b/global/const/game.gd
@@ -6,9 +6,9 @@ const WORKER_ROLE_RESOURCE: Array[String] = [WORKER_RESOURCE_ID, "swordsman"]
 const VERSION_MAJOR: String = "prototype"
 const VERSION_MINOR: String = "week 11"
 
-const params: Dictionary = params_prod  #params_prod  #params_debug
+const params: Dictionary = PARAMS_PROD  #PARAMS_PROD  #PARAMS_DEBUG
 
-const params_debug: Dictionary = {
+const PARAMS_DEBUG: Dictionary = {
 	"cycle_seconds": 2,
 	"enemy_cycle_seconds": 3,
 	"enemy_click_damage": -10,
@@ -34,7 +34,7 @@ const params_debug: Dictionary = {
 	"deaths_door_no_info": true
 }
 
-const params_prod: Dictionary = {
+const PARAMS_PROD: Dictionary = {
 	"cycle_seconds": 5,
 	"enemy_cycle_seconds": 3,
 	"enemy_click_damage": 0,

--- a/global/const/locale/locale_en.gd
+++ b/global/const/locale/locale_en.gd
@@ -1,29 +1,32 @@
 class_name LocaleEn
 
-const en: Dictionary = {
-	"ui_label": LocaleEn.ui_label,
-	"npc_hover_info": LocaleEn.npc_hover_info,
-	"npc_hover_title": LocaleEn.npc_hover_title,
-	"npc_click_info": LocaleEn.npc_click_info,
-	"npc_click_title": LocaleEn.npc_click_title,
-	"scale_settings_info": LocaleEn.scale_settings_info,
-	"enemy_data_title": LocaleEn.enemy_data_title,
-	"enemy_data_info": LocaleEn.enemy_data_info,
-	"enemy_data_option_title": LocaleEn.enemy_data_option_title,
-	"resource_generator_label": LocaleEn.resource_generator_label,
-	"resource_generator_title": LocaleEn.resource_generator_title,
-	"resource_generator_flavor": LocaleEn.resource_generator_flavor,
-	"resource_generator_max_flavor": LocaleEn.resource_generator_max_flavor,
-	"resource_generator_display_name": LocaleEn.resource_generator_display_name,
-	"worker_role_title": LocaleEn.worker_role_title,
-	"worker_role_flavor": LocaleEn.worker_role_flavor,
-	"tab_data_titles": LocaleEn.tab_data_titles,
-	"event_data_text": LocaleEn.event_data_text,
-	"npc_event_text": LocaleEn.npc_event_text,
-	"npc_event_options": LocaleEn.npc_event_options
+const EN: Dictionary = {
+	"ui_label": LocaleEn.UI_LABEL,
+	"npc_hover_info": LocaleEn.NPC_HOVER_INFO,
+	"npc_hover_title": LocaleEn.NPC_HOVER_TITLE,
+	"npc_click_info": LocaleEn.NPC_CLICK_INFO,
+	"npc_click_title": LocaleEn.NPC_CLICK_TITLE,
+	"scale_settings_info": LocaleEn.SCALE_SETTINGS_INFO,
+	"enemy_data_title": LocaleEn.ENEMY_DATA_TITLE,
+	"enemy_data_info": LocaleEn.ENEMY_DATA_INFO,
+	"enemy_data_option_title": LocaleEn.ENEMY_DATA_OPTION_TITLE,
+	"resource_generator_label": LocaleEn.RESOURCE_GENERATOR_LABEL,
+	"resource_generator_title": LocaleEn.RESOURCE_GENERATOR_TITLE,
+	"resource_generator_flavor": LocaleEn.RESOURCE_GENERATOR_FLAVOR,
+	"resource_generator_max_flavor": LocaleEn.RESOURCE_GENERATOR_MAX_FLAVOR,
+	"resource_generator_display_name": LocaleEn.RESOURCE_GENERATOR_DISPLAY_NAME,
+	"worker_role_title": LocaleEn.WORKER_ROLE_TITLE,
+	"worker_role_flavor": LocaleEn.WORKER_ROLE_FLAVOR,
+	"tab_data_titles": LocaleEn.TAB_DATA_TITLES,
+	"event_data_text": LocaleEn.EVENT_DATA_TEXT,
+	"npc_event_text": LocaleEn.NPC_EVENT_TEXT,
+	"npc_event_options": LocaleEn.NPC_EVENT_OPTIONS
 }
 
-const ui_label: Dictionary = {
+# File contains long labels that we don't want to lint
+# gdlint:disable = max-line-length
+
+const UI_LABEL: Dictionary = {
 	"name": "Name",
 	"playtime": "Playtime",
 	"last_played": "Last Played",
@@ -56,19 +59,19 @@ const ui_label: Dictionary = {
 	"sfx": "SFX"
 }
 
-const npc_hover_title: Dictionary = {}
+const NPC_HOVER_TITLE: Dictionary = {}
 
-const npc_hover_info: Dictionary = {
+const NPC_HOVER_INFO: Dictionary = {
 	"cat": "Suspicious looking creature, somehow able to produce human speech."
 }
 
-const npc_click_title: Dictionary = {"cat": "Click The Cat ??"}
+const NPC_CLICK_TITLE: Dictionary = {"cat": "Click The Cat ??"}
 
-const npc_click_info: Dictionary = {
+const NPC_CLICK_INFO: Dictionary = {
 	"cat": "I do not want to do that... all my senses, are screaming... Do. Not. Click. Her."
 }
 
-const enemy_data_title: Dictionary = {
+const ENEMY_DATA_TITLE: Dictionary = {
 	"ambassador": "The Ambassador Of Darkness",
 	"rabbit": "A Child Of Darkness",
 	"bird": "The Messenger Of Darkness",
@@ -82,7 +85,7 @@ const enemy_data_title: Dictionary = {
 	"angel": "The Angel Of Death, Vessel Of Darkness"
 }
 
-const enemy_data_option_title: Dictionary = {
+const ENEMY_DATA_OPTION_TITLE: Dictionary = {
 	"rabbit-2": "Soul Of Child",
 	"bird-2": "Soul Of Messenger",
 	"wolf-2": "Soul Of Beast",
@@ -107,7 +110,7 @@ const enemy_data_option_title: Dictionary = {
 	"null-1": "+20% swordsman to click"
 }
 
-const enemy_data_info: Dictionary = {
+const ENEMY_DATA_INFO: Dictionary = {
 	"ambassador": "This ancient colossal beast blocks the way towards the edge of the forest.",
 	"rabbit":
 	"Seemingly innocent creature, moving silently through the forest. It does not want to be clicked.",
@@ -126,7 +129,7 @@ const enemy_data_info: Dictionary = {
 	"angel": "Celestial being, a conduit for everything that was and will be. It remainsSs silent."
 }
 
-const resource_generator_label: Dictionary = {
+const RESOURCE_GENERATOR_LABEL: Dictionary = {
 	"CREEK": "Dredge",
 	"FOREST": "Scavenge",
 	"WILD": "Hunting Trip",
@@ -162,7 +165,7 @@ const resource_generator_label: Dictionary = {
 	"worker": ""
 }
 
-const resource_generator_title: Dictionary = {
+const RESOURCE_GENERATOR_TITLE: Dictionary = {
 	"CREEK": "Dredge the Creek",
 	"FOREST": "Scavenge the Forest",
 	"WILD": "Hunt the Wilderness",
@@ -198,7 +201,7 @@ const resource_generator_title: Dictionary = {
 	"worker": ""
 }
 
-const resource_generator_flavor: Dictionary = {
+const RESOURCE_GENERATOR_FLAVOR: Dictionary = {
 	"CREEK": "The bottom of the shallow creek is ready for picking.",
 	"FOREST": "Things are waiting to be found within.",
 	"WILD": "The deep forest howls and screeches.",
@@ -234,7 +237,7 @@ const resource_generator_flavor: Dictionary = {
 	"worker": ""
 }
 
-const resource_generator_max_flavor: Dictionary = {
+const RESOURCE_GENERATOR_MAX_FLAVOR: Dictionary = {
 	"CREEK": "",
 	"FOREST": "",
 	"WILD": "",
@@ -271,7 +274,7 @@ const resource_generator_max_flavor: Dictionary = {
 	"worker": ""
 }
 
-const resource_generator_display_name: Dictionary = {
+const RESOURCE_GENERATOR_DISPLAY_NAME: Dictionary = {
 	"CREEK": "",
 	"FOREST": "",
 	"WILD": "",
@@ -306,7 +309,7 @@ const resource_generator_display_name: Dictionary = {
 	"worker": "Peasant"
 }
 
-const worker_role_title: Dictionary = {
+const WORKER_ROLE_TITLE: Dictionary = {
 	"clay_digger": "",
 	"coal_miner": "",
 	"experience": "",
@@ -330,7 +333,7 @@ const worker_role_title: Dictionary = {
 	"worker": "Peasant"
 }
 
-const worker_role_flavor: Dictionary = {
+const WORKER_ROLE_FLAVOR: Dictionary = {
 	"clay_digger": "The muddy lake keeps her secrets, for now.",
 	"coal_miner": "It takes a keen eye to spot some surface coal ore.",
 	"experience": "",
@@ -354,7 +357,7 @@ const worker_role_flavor: Dictionary = {
 	"worker": "Scavenge and gather food wherever they can."
 }
 
-const tab_data_titles: Dictionary = {
+const TAB_DATA_TITLES: Dictionary = {
 	"world":
 	[
 		" World ",
@@ -379,7 +382,7 @@ const tab_data_titles: Dictionary = {
 	"settings": [" @ "]
 }
 
-const event_data_text: Dictionary = {
+const EVENT_DATA_TEXT: Dictionary = {
 	"automation":
 	"Passive production of all resources is increasing! The age of automation is upon us.",
 	"cat_gift":
@@ -484,7 +487,7 @@ const event_data_text: Dictionary = {
 	"absolve_9": "The prince laughs at my mercy. Still, he agrees to follow along.",
 	"lore_beacon": "The lit beacon pierces the dark sky. For the first time, I can see the stars..."
 }
-const npc_event_text: Dictionary = {
+const NPC_EVENT_TEXT: Dictionary = {
 	"cat_intro": "I smell you from afar. Are you lost?",
 	"cat_peek": "",
 	"cat_talk_A1": "I thought so. You are different... not from the ForesSst.",
@@ -503,7 +506,7 @@ const npc_event_text: Dictionary = {
 	"cat_talk_C0": "You really defeated it by yoursSself... I underestimated you."
 }
 
-const npc_event_options: Dictionary = {
+const NPC_EVENT_OPTIONS: Dictionary = {
 	"cat_intro": ["Yes", "No"],
 	"cat_peek": [],
 	"cat_talk_A1": ["?"],
@@ -522,7 +525,7 @@ const npc_event_options: Dictionary = {
 	"cat_talk_C0": [":)"]
 }
 
-const scale_settings_info: Dictionary = {
+const SCALE_SETTINGS_INFO: Dictionary = {
 	-1: "???",
 	1: "One by one.",
 	10: "Huh, that's quite the crowd. I have never seen these men in my life.",

--- a/global/utils/number_utils.gd
+++ b/global/utils/number_utils.gd
@@ -117,10 +117,10 @@ static func is_valid_int_64(input_string: String) -> bool:
 
 	if number_string.length() > max_int_string.length():
 		return false
-	elif number_string.length() < max_int_string.length():
+	if number_string.length() < max_int_string.length():
 		return true
 
 	if number_string.begins_with("-"):
 		return number_string >= min_int_string
-	else:
-		return number_string <= max_int_string
+
+	return number_string <= max_int_string

--- a/global/utils/pow_utils.gd
+++ b/global/utils/pow_utils.gd
@@ -1,6 +1,6 @@
 class_name PowUtils
 
-const pows: Dictionary = {
+const POWS: Dictionary = {
 	2:
 	{
 		0: 1,
@@ -202,7 +202,7 @@ const pows: Dictionary = {
 }
 
 
-static func pow_(base: int, exponent: int) -> int:
+static func pow_int(base: int, exponent: int) -> int:
 	if base == 0:
 		return 0
 	if base == 1:
@@ -210,4 +210,4 @@ static func pow_(base: int, exponent: int) -> int:
 	if base > 10 or exponent > 18:
 		var zero: int = 0
 		return zero / zero
-	return pows[base][exponent]
+	return POWS[base][exponent]

--- a/global/utils/roman_numeral_utils.gd
+++ b/global/utils/roman_numeral_utils.gd
@@ -1,6 +1,6 @@
 class_name RomanNumeralUtils
 
-const value: Array[int] = [
+const VALUE: Array[int] = [
 	1,
 	4,
 	5,
@@ -51,7 +51,7 @@ const value: Array[int] = [
 	900000000000,
 	1000000000000
 ]
-const symbol: Array[String] = [
+const SYMBOL: Array[String] = [
 	"I",
 	"IV",
 	"V",
@@ -105,16 +105,16 @@ const symbol: Array[String] = [
 
 
 static func to_roman_numeral(n: int) -> String:
-	if n > 4 * value[value.size() - 1]:
+	if n > 4 * VALUE[VALUE.size() - 1]:
 		return ""
 
 	var out: String = ""
-	var i: int = value.size() - 1
+	var i: int = VALUE.size() - 1
 	while n:
-		var div: int = n / value[i]
-		n %= value[i]
+		var div: int = n / VALUE[i]
+		n %= VALUE[i]
 		while div:
-			out += symbol[i]
+			out += SYMBOL[i]
 			div -= 1
 		i -= 1
 	return out

--- a/resources/game_data/cost_function/exponential/exponential.gd
+++ b/resources/game_data/cost_function/exponential/exponential.gd
@@ -2,4 +2,4 @@ extends CostFunction
 
 
 func get_cost(base_cost: int, level: int) -> int:
-	return PowUtils.pow_(base_cost, level)
+	return PowUtils.pow_int(base_cost, level)

--- a/scenes/autostart/save_file_picker/save_file_picker.gd
+++ b/scenes/autostart/save_file_picker/save_file_picker.gd
@@ -37,8 +37,8 @@ func _change_scene_to_main_scene(save_file_name: String, metadata_name: String =
 
 
 func _force_unique_save_file_name(save_file_name: String) -> String:
-	while SaveFile.SAVE_DATAS.has(save_file_name):
-		return StringUtils.increment_int_suffix(save_file_name, SaveFile.SAVE_DATAS.keys())
+	while SaveFile.save_datas.has(save_file_name):
+		return StringUtils.increment_int_suffix(save_file_name, SaveFile.save_datas.keys())
 	return save_file_name
 
 

--- a/scenes/ui/manager_settings_container/manager_settings_container.gd
+++ b/scenes/ui/manager_settings_container/manager_settings_container.gd
@@ -31,7 +31,7 @@ func _initialize() -> void:
 	max_scale = max(1, ArrayUtils.max_element(SaveFile.workers.values() + [0]))
 	var button_scale: int = min_scale
 	var padding: int = MAX_SCALE_BUTTONS
-	while max_scale > PowUtils.pow_(10, padding):
+	while max_scale > PowUtils.pow_int(10, padding):
 		padding += 1
 		button_scale *= 10
 	while button_scale <= max_scale and h_box_container.get_child_count() < MAX_SCALE_BUTTONS:
@@ -67,7 +67,7 @@ func _handle_on_worker_updated(total: int) -> void:
 	if total > max_scale:
 		var count: int = h_box_container.get_child_count()
 		var exponent: int = max(0, count - 1)
-		if total > PowUtils.pow_(10, exponent):
+		if total > PowUtils.pow_int(10, exponent):
 			_initialize()
 		max_scale = total
 

--- a/scenes/ui/save_file_tracker/save_file_tracker.gd
+++ b/scenes/ui/save_file_tracker/save_file_tracker.gd
@@ -1,16 +1,16 @@
-extends MarginContainer
 class_name SaveFileTracker
-
-const DEFAULT_SAVE_FILE_NAME: String = "unnamed"
+extends MarginContainer
 
 signal load_save_file(save_file_name: String)
 signal delete_save_file(save_file_name: String)
 signal new_save_file(save_file_name: String)
 signal new_input_set(save_file_name: String, new_text: String, old_text: String)
 
-@onready var save_item_v_box_container: VBoxContainer = %SaveItemVBoxContainer
+const DEFAULT_SAVE_FILE_NAME: String = "unnamed"
 
 @export var save_file_item_scene: PackedScene
+
+@onready var save_item_v_box_container: VBoxContainer = %SaveItemVBoxContainer
 
 ###############
 ## overrides ##
@@ -43,7 +43,7 @@ func get_last_played_save_file_name() -> String:
 
 func _load_save_files() -> void:
 	_add_item({}, DEFAULT_SAVE_FILE_NAME, true)
-	var save_datas: Dictionary = SaveFile.SAVE_DATAS
+	var save_datas: Dictionary = SaveFile.save_datas
 	for save_file_name: String in save_datas:
 		var save_data: Dictionary = save_datas[save_file_name]
 		var metadata: Dictionary = save_data.get("metadata", {})
@@ -76,7 +76,7 @@ func _connect_item_signals(save_file_item: SaveFileItem) -> void:
 
 
 func _on_ready() -> void:
-	if SaveFile.SAVE_DATAS.is_empty():
+	if SaveFile.save_datas.is_empty():
 		new_save_file.emit(DEFAULT_SAVE_FILE_NAME)
 
 


### PR DESCRIPTION
This PR is already getting big enough, so it's time to check if everyone agrees with the changes, or if we want to change some linter settings instead.

This now fixes every problem in the `global` directory except for the `params` const in `game.gd`, because that's used in a lot of places.

Most changes in this PR are of the types:
- Ordering of the declaration types at the top of a file
- `const` names have to be capitalized
- Class-scope variable names shouldn't be capitalized
- Functions can't start with two underscores
- Function variable names can't start with an underscore