### PR TITLE
ADF 41 | gdlint github action

### DIFF
--- a/.github/workflows/gdlint.yml
+++ b/.github/workflows/gdlint.yml
@@ -1,0 +1,47 @@
+﻿# Workflow to automatically lint gdscript code
+name: gdlint on push
+
+on:
+  [push, pull_request]
+
+jobs:
+  gdlint:
+    name: gdlint code
+    runs-on: ubuntu-latest
+    
+    env:
+      PROBLEMS_THRESHOLD: 88 # The allowed amount of linter problems
+
+    steps:
+      # Check out the repository
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      # Ensure python is installed
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.10'
+
+      # Install gdtoolkit
+      - name: Install Dependencies
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install 'gdtoolkit==4.*'
+
+      # Lint all the code directories (except addons) and capture the output
+      # "|| true" make sure the github action doesn't stop when there are problems
+      - name: Lint code
+        run: |
+          gdlint assets global resources scenes > gdlint_output.txt 2>&1 || true
+          cat gdlint_output.txt
+
+      # Parse the output and compare with the threshold
+      - name: Check linter results
+        run: |
+          PROBLEMS=$(grep -oP 'Failure: \K\d+' gdlint_output.txt || echo "0")
+          echo "Problems found: $PROBLEMS, threshold is: $PROBLEMS_THRESHOLD"
+          if [ "$PROBLEMS" -gt "$PROBLEMS_THRESHOLD" ]; then
+            echo "Too many linter problems"
+            exit 1
+          fi


### PR DESCRIPTION
Added a gdlint github action, with variable problems threshold

Mainly copied this file: https://github.com/GodotVR/godot-xr-tools/blob/master/.github/workflows/gdlint-on-push.yml
And then added a step to compare with the threshold

**About the threshold**
I think it could be useful, because there may be situations where you introduce a linter problem, but it's not something you want to fix now. So then you can increase the threshold and still merge (without "hiding" the problem by adding an ignore statement in the code)

**To test**
You can check the action that ran on this PR.
You can also test github actions locally by installing `act`: https://github.com/nektos/act/releases (you'll also need docker installed)
In the root directory run:
```
act -j gdlint
```